### PR TITLE
Replace the version on the target index_files rather instead of appending

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Build Script: Replace version instead of appending to the index file.
+
 
 ## 2024/05/21 v0.0.2
 - Initial release

--- a/cratedb_sqlparse_js/cratedb_sqlparse/index.js
+++ b/cratedb_sqlparse_js/cratedb_sqlparse/index.js
@@ -1,2 +1,3 @@
 import {sqlparse} from "./parser.js";
 export {sqlparse};
+export const __cratedb_version__ = "5.6.4"

--- a/cratedb_sqlparse_py/cratedb_sqlparse/__init__.py
+++ b/cratedb_sqlparse_py/cratedb_sqlparse/__init__.py
@@ -1,3 +1,5 @@
 from .parser import ParsingException, sqlparse
 
 __all__ = ["sqlparse", "ParsingException"]
+
+__cratedb_version__ = "5.6.4"


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
In the build script, replace the old version with the new one rather than just appending the variable again, otherwise if you run the script several times you'd get the variable multiple times.

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
