### PR TITLE
JavaScript: Fix package entrypoint. Naming things.

### DIFF
--- a/cratedb_sqlparse_js/package-lock.json
+++ b/cratedb_sqlparse_js/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cratedb-sqlparse",
+  "name": "@cratedb/cratedb-sqlparse",
   "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cratedb-sqlparse",
+      "name": "@cratedb/cratedb-sqlparse",
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {

--- a/cratedb_sqlparse_js/package.json
+++ b/cratedb_sqlparse_js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cratedb-sqlparse",
+  "name": "@cratedb/cratedb-sqlparse",
   "version": "0.0.2",
   "type": "module",
   "files": [

--- a/cratedb_sqlparse_js/vite.config.js
+++ b/cratedb_sqlparse_js/vite.config.js
@@ -10,8 +10,8 @@ export default defineConfig({
     build: {
         lib: {
             // Could also be a dictionary or array of multiple entry points
-            entry: resolve(__dirname, 'parser/index.js'),
-            name: 'cratedb_sqlparse', // the proper extensions will be added
+            entry: resolve(__dirname, 'cratedb_sqlparse/index.js'),
+            name: '@cratedb/cratedb-sqlparse', // the proper extensions will be added
             fileName: 'sqlparse',
         }, rollupOptions: {
             // make sure to externalize deps that shouldn't be bundled

--- a/cratedb_sqlparse_js/vite.config.js
+++ b/cratedb_sqlparse_js/vite.config.js
@@ -5,13 +5,14 @@ import {
 import {
     defineConfig
 } from 'vite'
+import packageJson from './package.json';
 
 export default defineConfig({
     build: {
         lib: {
             // Could also be a dictionary or array of multiple entry points
             entry: resolve(__dirname, 'cratedb_sqlparse/index.js'),
-            name: '@cratedb/cratedb-sqlparse', // the proper extensions will be added
+            name: packageJson.name, // the proper extensions will be added
             fileName: 'sqlparse',
         }, rollupOptions: {
             // make sure to externalize deps that shouldn't be bundled


### PR DESCRIPTION
## About

- The package intends to be published as `@cratedb/cratedb-sqlparse`.
- The package entrypoint was wrong, so `npm run build` croaked.
