### PR TITLE
Change error handling strategy and add verbose errors

### DIFF
--- a/cratedb_sqlparse_py/README.md
+++ b/cratedb_sqlparse_py/README.md
@@ -27,7 +27,7 @@ query = """
     SELECT * FROM SYS.SHARDS;
     INSERT INTO doc.tbl VALUES (1);
 """
-statements = sqlparse(query)
+statements = sqlparse(query, raise_exception=True)
 
 print(len(statements))
 # 2
@@ -43,17 +43,28 @@ print(select_query.type)
 print(select_query.tree)
 # (statement (query (queryNoWith (queryTerm (querySpec SELECT (selectItem *) FROM (relation (aliasedRelation (relationPrimary (table (qname (ident (unquotedIdent SYS)) . (ident (unquotedIdent (nonReserved SHARDS)))))))))))))
 
-sqlparse('SUUULECT * FROM sys.shards')
-# cratedb_sqlparse.parser.parser.ParsingException: line1:0 mismatched input 'SUUULECT' expecting {'SELECT', 'DEALLOCATE', ...}
+sqlparse('SEEELECT * FROM sys.shards')
+# cratedb_sqlparse.parser.parser.ParsingException: line1:0 mismatched input 'SEEELECT' expecting {'SELECT', 'DEALLOCATE', ...}
 ```
 
 
 ## Development
 ```shell
 git clone https://github.com/crate/cratedb-sqlparse
+
 cd cratedb-sqlparse/cratedb_sqlparse_py
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --editable='.[develop,generate,release,test]'
 poe check
+```
+
+### Run only tests
+```shell
+poe test
+```
+
+### Run only one test
+```shell
+poe test -k test_sqlparse_collects_exceptions_2
 ```

--- a/cratedb_sqlparse_py/pyproject.toml
+++ b/cratedb_sqlparse_py/pyproject.toml
@@ -205,7 +205,7 @@ check = [
 format = [
   { cmd = "ruff format ." },
   # Configure Ruff not to auto-fix (remove!) unused variables (F841) and `print` statements (T201).
-  { cmd = "ruff check --fix --ignore=ERA --ignore=F401 --ignore=F841 --ignore=T20 ." },
+  { cmd = "ruff check --fix --ignore=ERA --ignore=F401 --ignore=F841 --ignore=T20 --ignore=E501 ." },
   { cmd = "pyproject-fmt --keep-full-version pyproject.toml" },
 ]
 

--- a/cratedb_sqlparse_py/tests/test_exceptions.py
+++ b/cratedb_sqlparse_py/tests/test_exceptions.py
@@ -1,0 +1,79 @@
+import pytest
+
+
+def test_exception_message():
+    from cratedb_sqlparse import sqlparse
+
+    r = sqlparse("""
+         SELEC 1;
+        SELECT A, B, C, D FROM tbl1;
+        SELECT D, A FROM tbl1 WHERE;
+    """)
+    expected_message = "InputMismatchException[line 2:9 mismatched input 'SELEC' expecting {'SELECT', 'DEALLOCATE', 'FETCH', 'END', 'WITH', 'CREATE', 'ALTER', 'KILL', 'CLOSE', 'BEGIN', 'START', 'COMMIT', 'ANALYZE', 'DISCARD', 'EXPLAIN', 'SHOW', 'OPTIMIZE', 'REFRESH', 'RESTORE', 'DROP', 'INSERT', 'VALUES', 'DELETE', 'UPDATE', 'SET', 'RESET', 'COPY', 'GRANT', 'DENY', 'REVOKE', 'DECLARE'}]"
+    expected_message_2 = "\n         SELEC 1;\n         ^^^^^\n        SELECT A, B, C, D FROM tbl1;\n        SELECT D, A FROM tbl1 WHERE;\n    "
+    assert r[0].exception.error_message == expected_message
+    assert r[0].exception.original_query_with_error_marked == expected_message_2
+
+
+def test_sqlparse_raises_exception():
+    from cratedb_sqlparse import ParsingException, sqlparse
+
+    query = "SELCT 2"
+
+    with pytest.raises(ParsingException):
+        sqlparse(query, raise_exception=True)
+
+
+def test_sqlparse_collects_exception():
+    from cratedb_sqlparse import sqlparse
+
+    query = "SELCT 2"
+
+    statements = sqlparse(query)
+    assert statements[0]
+
+
+def test_sqlparse_collects_exceptions():
+    from cratedb_sqlparse import sqlparse
+
+    r = sqlparse("""
+        SELECT A FROM tbl1 where ;
+        SELECT 1;
+        SELECT D, A FROM tbl1 WHERE;
+    """)
+
+    assert len(r) == 3
+
+    assert r[0].exception is not None
+    assert r[1].exception is None
+    assert r[2].exception is not None
+
+
+def test_sqlparse_collects_exceptions_2():
+    from cratedb_sqlparse import sqlparse
+
+    # Different combination of the query to validate
+    r = sqlparse("""
+         SELEC 1;
+        SELECT A, B, C, D FROM tbl1;
+        SELECT D, A FROM tbl1 WHERE;
+    """)
+
+    assert r[0].exception is not None
+    assert r[1].exception is None
+    assert r[2].exception is not None
+
+
+def test_sqlparse_collects_exceptions_3():
+    from cratedb_sqlparse import sqlparse
+
+    # Different combination of the query to validate
+    r = sqlparse("""
+        SELECT 1;
+        SELECT A, B, C, D FROM tbl1;
+        INSERT INTO doc.tbl VALUES (1,2, 'three', ['four']);
+    """)
+
+    assert r[0].exception is None
+    assert r[1].exception is None
+    assert r[2].exception is None

--- a/cratedb_sqlparse_py/tests/test_exceptions.py
+++ b/cratedb_sqlparse_py/tests/test_exceptions.py
@@ -9,8 +9,8 @@ def test_exception_message():
         SELECT A, B, C, D FROM tbl1;
         SELECT D, A FROM tbl1 WHERE;
     """)
-    expected_message = "InputMismatchException[line 2:9 mismatched input 'SELEC' expecting {'SELECT', 'DEALLOCATE', 'FETCH', 'END', 'WITH', 'CREATE', 'ALTER', 'KILL', 'CLOSE', 'BEGIN', 'START', 'COMMIT', 'ANALYZE', 'DISCARD', 'EXPLAIN', 'SHOW', 'OPTIMIZE', 'REFRESH', 'RESTORE', 'DROP', 'INSERT', 'VALUES', 'DELETE', 'UPDATE', 'SET', 'RESET', 'COPY', 'GRANT', 'DENY', 'REVOKE', 'DECLARE'}]"
-    expected_message_2 = "\n         SELEC 1;\n         ^^^^^\n        SELECT A, B, C, D FROM tbl1;\n        SELECT D, A FROM tbl1 WHERE;\n    "
+    expected_message = "InputMismatchException[line 2:9 mismatched input 'SELEC' expecting {'SELECT', 'DEALLOCATE', 'FETCH', 'END', 'WITH', 'CREATE', 'ALTER', 'KILL', 'CLOSE', 'BEGIN', 'START', 'COMMIT', 'ANALYZE', 'DISCARD', 'EXPLAIN', 'SHOW', 'OPTIMIZE', 'REFRESH', 'RESTORE', 'DROP', 'INSERT', 'VALUES', 'DELETE', 'UPDATE', 'SET', 'RESET', 'COPY', 'GRANT', 'DENY', 'REVOKE', 'DECLARE'}]"  # noqa
+    expected_message_2 = "\n         SELEC 1;\n         ^^^^^\n        SELECT A, B, C, D FROM tbl1;\n        SELECT D, A FROM tbl1 WHERE;\n    "  # noqa
     assert r[0].exception.error_message == expected_message
     assert r[0].exception.original_query_with_error_marked == expected_message_2
 

--- a/cratedb_sqlparse_py/tests/test_lexer.py
+++ b/cratedb_sqlparse_py/tests/test_lexer.py
@@ -44,13 +44,20 @@ def test_sqlparse_dollar_string():
     assert r[0].query == query
 
 
-def test_sqlparse_raises_exception():
-    from cratedb_sqlparse import ParsingException, sqlparse
+def test_sqlparse_multiquery_edge_case():
+    # Test for https://github.com/crate/cratedb-sqlparse/issues/28,
+    # if this ends up parsing 3 statements, we can change this test,
+    # it's here so we can programmatically track if the behavior changes.
+    from cratedb_sqlparse import sqlparse
 
-    query = "SALUT MON AMIE"
+    query = """
+    SELECT A FROM tbl1 where ;
+    SELEC 1;
+    SELECT D, A FROM tbl1 WHERE;
+"""
 
-    with pytest.raises(ParsingException):
-        sqlparse(query)
+    statements = sqlparse(query)
+    assert len(statements) == 1
 
 
 def test_sqlparse_is_case_insensitive():

--- a/cratedb_sqlparse_py/tests/test_lexer.py
+++ b/cratedb_sqlparse_py/tests/test_lexer.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_sqlparser_one_statement(query=None):
     from cratedb_sqlparse import sqlparse
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Issue #2

This is one of the first pieces required to finish the feature and its only implemented in Python for early feedback/validation. 

Main changes of PR:
- Throwing antlr4 parse errors as exceptions is now only enabled by `raise_exception` API influenced by [DRF Validators](https://www.django-rest-framework.org/api-guide/exceptions/#validationerror)

- Default behaviour is not to raise an exception, the reason is that it forces clients to try/catch errors, when you already work with CrateDB in the HTTP protocol you are used to check the json response, rather than catching exceptions, this change of behaviour aims to make integrating with this library as similar as possible as with CrateDB.

- Implements an `ExceptionCollectorListener` that collects all errors that are caught, (remember that we use `parser.statements`, to support running several queries on the frontends, so several errors can happen simultaneously)

- Adds more verbose errors 

**_The main issue I would like help with the review:_** <-------------------------------------
- Whenever we collect the errors I just add the errors to a list for further processing:
```python
class ExceptionCollectorListener(ErrorListener):
    """
    Error listener that collects all errors into errors for further processing.
    Based partially on https://github.com/antlr/antlr4/issues/396
    """

    def __init__(self):
        self.errors = []

    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e):
        error = ParsingException(
            msg=msg,
            offending_token=offendingSymbol,
            e=e,
            query=e.ctx.parser.getTokenStream().getText(e.ctx.start, e.offendingToken.tokenIndex),
        )

        self.errors.append(error)

```


we lose the information on which statement the error belongs to, I tried with different ErrorStrategies and Error listeners but to no avail, also didn't find anything online.

My best effort is to try to match the error's offendingToken query, to any of the parsed statements:

```python
# Shortened for clarity purposes.
def find_suitable_error(statement, errors):
    for error in errors[:]:
        if error.query == statement.query:
            statement.exception = error
            errors.pop(errors.index(error))
```
There are a couple of edge cases that I covered but in short, it works reasonable well, even though I'm not a fan of it, maybe you folks way more experience in `antlr4 ` have an idea?

## Checklist

 - [x] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
