### PR TITLE
Improve heuristics of assigning an error to its statement

### DIFF
--- a/cratedb_sqlparse_py/tests/test_exceptions.py
+++ b/cratedb_sqlparse_py/tests/test_exceptions.py
@@ -24,6 +24,12 @@ def test_sqlparse_raises_exception():
         sqlparse(query, raise_exception=True)
 
 
+def test_sqlparse_not_raise_exception():
+    from cratedb_sqlparse import sqlparse
+
+    sqlparse("SELECT COUNT(*) FROM doc.tbl f WHERE f.id = 1;", raise_exception=True)
+
+
 def test_sqlparse_collects_exception():
     from cratedb_sqlparse import sqlparse
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Found an fixed an edge case where error was not being assigned to statement.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
