### PR TITLE
Extract metadata from the query into the statement.

### DIFF
--- a/cratedb_sqlparse_py/README.md
+++ b/cratedb_sqlparse_py/README.md
@@ -106,9 +106,6 @@ Note:
 It will only raise the first exception if finds, even if you pass in several statements.
 
 
-
-
-
 ## Development
 
 ### Set up environment

--- a/cratedb_sqlparse_py/cratedb_sqlparse/AstBuilder.py
+++ b/cratedb_sqlparse_py/cratedb_sqlparse/AstBuilder.py
@@ -1,0 +1,50 @@
+import typing as t
+
+from cratedb_sqlparse.generated_parser.SqlBaseParser import SqlBaseParser
+from cratedb_sqlparse.generated_parser.SqlBaseParserVisitor import SqlBaseParserVisitor
+
+
+class AstBuilder(SqlBaseParserVisitor):
+    """
+    The class implements the antlr4 visitor pattern similar to how we do it in CrateDB
+    https://github.com/crate/crate/blob/master/libs/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+
+    The biggest difference is that in CrateDB, `AstBuilder`, visitor methods
+    return a specialized Statement visitor.
+
+    Sqlparse just extracts whatever data it needs from the context and injects it to the current
+    visited statement, enriching its metadata.
+    """
+
+    @property
+    def stmt(self):
+        if not hasattr(self, "_stmt"):
+            raise Exception("You should call `enrich` first, that is the entrypoint.")
+        return self._stmt
+
+    @stmt.setter
+    def stmt(self, value):
+        self._stmt = value
+
+    def enrich(self, stmt) -> None:
+        self.stmt = stmt
+        self.visit(self.stmt.ctx)
+
+    def visitTableName(self, ctx: SqlBaseParser.TableNameContext):
+        fqn = ctx.qname()
+        parts = self.get_text(fqn).replace('"', "").split(".")
+
+        if len(parts) == 1:
+            name = parts[0]
+            schema = None
+        else:
+            schema, name = parts
+
+        self.stmt.metadata.table_name = name
+        self.stmt.metadata.schema = schema
+
+    def get_text(self, node) -> t.Optional[str]:
+        """Gets the text representation of the node or None if it doesn't have one"""
+        if node:
+            return node.getText()
+        return node

--- a/cratedb_sqlparse_py/tests/test_enricher.py
+++ b/cratedb_sqlparse_py/tests/test_enricher.py
@@ -1,0 +1,46 @@
+def test_table_metadata():
+    from cratedb_sqlparse import sqlparse
+    from cratedb_sqlparse.parser import Metadata
+
+    query = "SELECT 1; SELECT 2;"
+    stmts = sqlparse(query)
+    for stmt in stmts:
+        assert hasattr(stmt, "metadata")
+        assert isinstance(stmt.metadata, Metadata)
+
+
+def test_table_name_statement():
+    from cratedb_sqlparse import sqlparse
+
+    query = "CREATE TABLE doc.tbl2 (a TEXT)"
+
+    stmts = sqlparse(query)
+    stmt = stmts[0]
+
+    assert stmt.metadata.schema == "doc"
+    assert stmt.metadata.table_name == "tbl2"
+
+
+def test_table_name_statements():
+    from cratedb_sqlparse import sqlparse
+
+    query = """
+    SELECT A,B,C,D,E FROM doc.tbl1;
+    SELECT A,B FROM "doc"."tbl1";
+    SELECT A,B FROM "tbl1";
+    SELECT A,B FROM tbl1;
+    """
+
+    stmts = sqlparse(query=query)
+
+    assert stmts[0].metadata.schema == "doc"
+    assert stmts[0].metadata.table_name == "tbl1"
+
+    assert stmts[1].metadata.schema == "doc"
+    assert stmts[1].metadata.table_name == "tbl1"
+
+    assert stmts[2].metadata.schema is None
+    assert stmts[2].metadata.table_name == "tbl1"
+
+    assert stmts[3].metadata.schema is None
+    assert stmts[3].metadata.table_name == "tbl1"

--- a/setup_grammar.py
+++ b/setup_grammar.py
@@ -78,7 +78,9 @@ def compile_grammar(target: Antlr4Target):
         logger.info(f"Compiling grammar: {outfile}")
         subprocess.check_call(
             [
-                'antlr4', f'-Dlanguage={target.value}',
+                'antlr4',
+                f'-Dlanguage={target.value}',
+                '-visitor',
                 '-o',
                 str(PARSER_COMPILE_PATH / base_dir / sub_dir),
                 file['filename']


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Implements extracting metadata using an `AstBuilder` to enrich a `Statement`

Currently only gets the schema and table name.

Example:

```python
stmt = sqlparse("SELECT A, B FROM doc.tbl1")[0]

print(stmt.metadata)
# Metadata(schema='doc', table_name='tbl1')
```

Sets the foundation for more features in the future, like #31 .

## Checklist

 - [x] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
