### PR TITLE
Add `with_properties` and `interpolated_properties`

### DIFF
--- a/cratedb_sqlparse_py/README.md
+++ b/cratedb_sqlparse_py/README.md
@@ -118,7 +118,7 @@ from cratedb_sqlparse import sqlparse
 stmt = sqlparse("SELECT A, B FROM doc.tbl12")
 
 print(stmt.metadata)
-# Metadata(schema='doc', table_name='tbl12', interpolated_properties={}, with_properties={})
+# Metadata(schema='doc', table_name='tbl12', parameterized_properties={}, with_properties={})
 ```
 
 #### Query properties.
@@ -137,12 +137,12 @@ stmt = sqlparse("""
 """)[0]
 
 print(stmt.metadata)
-# Metadata(schema='doc', table_name='tbl12', interpolated_properties={}, with_properties={'allocation.max_retries': '5', 'blocks.metadata': 'false'})
+# Metadata(schema='doc', table_name='tbl12', parameterized_properties={}, with_properties={'allocation.max_retries': '5', 'blocks.metadata': 'false'})
 ```
 
-#### Interpolated properties.
+#### Parameterized properties.
 
-Interpolated properties are properties without a real defined value, marked with a dollar string,  `metadata.interpolated_properties`
+Parameterized properties are properties without a real defined value, marked with a dollar string,  `metadata.parameterized_properties`
 
 ```python
 from cratedb_sqlparse import sqlparse
@@ -155,10 +155,10 @@ stmt = sqlparse("""
 """)[0]
 
 print(stmt.metadata)
-# Metadata(schema='doc', table_name='tbl12', interpolated_properties={'blocks.metadata': '$1'}, with_properties={'allocation.max_retries': '5', 'blocks.metadata': '$1'})
+# Metadata(schema='doc', table_name='tbl12', parameterized_properties={'blocks.metadata': '$1'}, with_properties={'allocation.max_retries': '5', 'blocks.metadata': '$1'})
 ```
 
-In this case, `blocks.metadata` will be in `with_properties` and `interpolated_properties` as well.
+In this case, `blocks.metadata` will be in `with_properties` and `parameterized_properties` as well.
 
 For values to be picked up they need to start with a dollar `'$'` and be preceded by integers, e.g. `'$1'`, `'$123'` -
 `'$123abc'` would not be valid.

--- a/cratedb_sqlparse_py/cratedb_sqlparse/AstBuilder.py
+++ b/cratedb_sqlparse_py/cratedb_sqlparse/AstBuilder.py
@@ -32,7 +32,7 @@ class AstBuilder(SqlBaseParserVisitor):
 
     def visitTableName(self, ctx: SqlBaseParser.TableNameContext):
         fqn = ctx.qname()
-        parts = self.get_text(fqn).replace('"', "").split(".")
+        parts = self.get_text(fqn).split(".")
 
         if len(parts) == 1:
             name = parts[0]
@@ -49,13 +49,13 @@ class AstBuilder(SqlBaseParserVisitor):
         properties = {}
         interpolated_properties = {}
 
-        for property in node_properties:
-            key = self.get_text(property.ident())
-            value = self.get_text(property.expr())
+        for property_ in node_properties:
+            key = self.get_text(property_.ident())
+            value = self.get_text(property_.expr())
 
             properties[key] = value
 
-            if value[0] == "$":
+            if value and value[0] == "$":
                 # It might be a interpolated value, e.g. '$1'
                 if value[1:].isdigit():
                     interpolated_properties[key] = value
@@ -66,5 +66,5 @@ class AstBuilder(SqlBaseParserVisitor):
     def get_text(self, node) -> t.Optional[str]:
         """Gets the text representation of the node or None if it doesn't have one"""
         if node:
-            return node.getText()
+            return node.getText().replace("'", "").replace('"', "")
         return node

--- a/cratedb_sqlparse_py/cratedb_sqlparse/AstBuilder.py
+++ b/cratedb_sqlparse_py/cratedb_sqlparse/AstBuilder.py
@@ -43,6 +43,26 @@ class AstBuilder(SqlBaseParserVisitor):
         self.stmt.metadata.table_name = name
         self.stmt.metadata.schema = schema
 
+    def visitGenericProperties(self, ctx: SqlBaseParser.GenericPropertiesContext):
+        node_properties = ctx.genericProperty()
+
+        properties = {}
+        interpolated_properties = {}
+
+        for property in node_properties:
+            key = self.get_text(property.ident())
+            value = self.get_text(property.expr())
+
+            properties[key] = value
+
+            if value[0] == "$":
+                # It might be a interpolated value, e.g. '$1'
+                if value[1:].isdigit():
+                    interpolated_properties[key] = value
+
+        self.stmt.metadata.with_properties = properties
+        self.stmt.metadata.interpolated_properties = interpolated_properties
+
     def get_text(self, node) -> t.Optional[str]:
         """Gets the text representation of the node or None if it doesn't have one"""
         if node:

--- a/cratedb_sqlparse_py/cratedb_sqlparse/AstBuilder.py
+++ b/cratedb_sqlparse_py/cratedb_sqlparse/AstBuilder.py
@@ -47,7 +47,7 @@ class AstBuilder(SqlBaseParserVisitor):
         node_properties = ctx.genericProperty()
 
         properties = {}
-        interpolated_properties = {}
+        parameterized_properties = {}
 
         for property_ in node_properties:
             key = self.get_text(property_.ident())
@@ -56,12 +56,12 @@ class AstBuilder(SqlBaseParserVisitor):
             properties[key] = value
 
             if value and value[0] == "$":
-                # It might be a interpolated value, e.g. '$1'
+                # It might be a parameterized value, e.g. '$1'
                 if value[1:].isdigit():
-                    interpolated_properties[key] = value
+                    parameterized_properties[key] = value
 
         self.stmt.metadata.with_properties = properties
-        self.stmt.metadata.interpolated_properties = interpolated_properties
+        self.stmt.metadata.parameterized_properties = parameterized_properties
 
     def get_text(self, node) -> t.Optional[str]:
         """Gets the text representation of the node or None if it doesn't have one"""

--- a/cratedb_sqlparse_py/cratedb_sqlparse/parser.py
+++ b/cratedb_sqlparse_py/cratedb_sqlparse/parser.py
@@ -134,7 +134,7 @@ class Metadata:
 
     schema: str = None
     table_name: str = None
-    interpolated_properties: dict = dataclasses.field(default_factory=dict)
+    parameterized_properties: dict = dataclasses.field(default_factory=dict)
     with_properties: dict = dataclasses.field(default_factory=dict)
 
 

--- a/cratedb_sqlparse_py/cratedb_sqlparse/parser.py
+++ b/cratedb_sqlparse_py/cratedb_sqlparse/parser.py
@@ -134,6 +134,8 @@ class Metadata:
 
     schema: str = None
     table_name: str = None
+    interpolated_properties: dict = dataclasses.field(default_factory=dict)
+    with_properties: dict = dataclasses.field(default_factory=dict)
 
 
 class Statement:

--- a/cratedb_sqlparse_py/pyproject.toml
+++ b/cratedb_sqlparse_py/pyproject.toml
@@ -103,6 +103,7 @@ line-length = 120
 branch = false
 omit = [
   "tests/*",
+  "cratedb_sqlparse/generated_parser/*"
 ]
 source = ["cratedb_sqlparse"]
 

--- a/cratedb_sqlparse_py/tests/test_enricher.py
+++ b/cratedb_sqlparse_py/tests/test_enricher.py
@@ -44,3 +44,32 @@ def test_table_name_statements():
 
     assert stmts[3].metadata.schema is None
     assert stmts[3].metadata.table_name == "tbl1"
+
+
+def test_table_with_properties():
+    from cratedb_sqlparse import sqlparse
+
+    query = "CREATE TABLE tbl (A TEXT) WITH ('key' = 'val', 'key2' = 2, 'key3' = true)"
+
+    stmt = sqlparse(query)[0]
+    keys = ["key", "key2"]
+
+    assert all(x in stmt.metadata.with_properties for x in keys)
+    assert stmt.metadata.with_properties["key"] == "val"
+    assert stmt.metadata.with_properties["key2"] == "2"
+    assert stmt.metadata.with_properties["key3"] == "true"
+
+
+def test_with_with_interpolated_properties():
+    from cratedb_sqlparse import sqlparse
+
+    query = "CREATE TABLE tbl (A TEXT) WITH ('key' = $1, 'key2' = '$2')"
+
+    stmt = sqlparse(query)[0]
+    keys = ["key", "key2"]
+
+    # Has all the keys.
+    assert all(x in stmt.metadata.interpolated_properties for x in keys)
+    assert all(x in stmt.metadata.with_properties for x in keys)
+    assert stmt.metadata.with_properties["key"] == "$1"
+    assert stmt.metadata.with_properties["key2"] == "$2"

--- a/cratedb_sqlparse_py/tests/test_enricher.py
+++ b/cratedb_sqlparse_py/tests/test_enricher.py
@@ -60,7 +60,7 @@ def test_table_with_properties():
     assert stmt.metadata.with_properties["key3"] == "true"
 
 
-def test_with_with_interpolated_properties():
+def test_with_with_parameterized_properties():
     from cratedb_sqlparse import sqlparse
 
     query = "CREATE TABLE tbl (A TEXT) WITH ('key' = $1, 'key2' = '$2')"
@@ -69,7 +69,7 @@ def test_with_with_interpolated_properties():
     keys = ["key", "key2"]
 
     # Has all the keys.
-    assert all(x in stmt.metadata.interpolated_properties for x in keys)
+    assert all(x in stmt.metadata.parameterized_properties for x in keys)
     assert all(x in stmt.metadata.with_properties for x in keys)
     assert stmt.metadata.with_properties["key"] == "$1"
     assert stmt.metadata.with_properties["key2"] == "$2"


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This PR allows for extracting properties defined by `[ WITH ( parameter [= value] [, ... ] ) ]` statements.

For example:

```python
from cratedb_sqlparse import sqlparse

stmt = sqlparse("""
    CREATE TABLE doc.tbl12 (A TEXT) WITH (
      "allocation.max_retries" = 5,
      "blocks.metadata" = false
    );
""")[0]

print(stmt.metadata)
# Metadata(schema='doc', table_name='tbl12', interpolated_properties={}, with_properties={'allocation.max_retries': '5', 'blocks.metadata': 'false'})
```

It also handles the special case of what I call, `interpolated values` and #31 if you have a better name recommendation, please go ahead :P

## Checklist

 - [x] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
