### PR TITLE
Add valid pypi versioningit's version scheme

### DIFF
--- a/cratedb_sqlparse_py/pyproject.toml
+++ b/cratedb_sqlparse_py/pyproject.toml
@@ -9,6 +9,12 @@ requires = [
 method = "git"
 default-tag = "0.0.0"
 
+[tool.versioningit.next-version]
+method = "smallest"
+
+[tool.versioningit.format]
+distance = "{next_version}"
+
 [project]
 name = "cratedb-sqlparse"
 description = "Parsing utilities to validate and split SQL statements for CrateDB."


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Currently the generated version is not accepted by pypi

From __https://peps.python.org/pep-0440/__:

Local version identifiers SHOULD NOT be used when publishing upstream projects to a public index server, but MAY be used to identify private builds created directly from the project source. Local version identifiers 
## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
