### PR TITLE
Python: Set python version to just >=3.8

### DIFF
--- a/cratedb_sqlparse_py/pyproject.toml
+++ b/cratedb_sqlparse_py/pyproject.toml
@@ -33,7 +33,7 @@ license = { text = "Apache License 2.0" }
 authors = [
   { name = "Ivan Sanchez Valencia", email = "ivan.sanchezvalencia@crate.io" },
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
cratedb-sqlparse requires Python `<3.13,>=3.8`

If you create a new environment with poetry for example, the default version will be `^{yoursystempythonversion}`, for my system which uses 3.12 is `^3.12`, this translates to `>=3.13,<4.0`.

Making it incompatible if I don't change my local version.

This is the error:
![image](https://github.com/crate/cratedb-sqlparse/assets/37985796/8ef803d0-abab-4a4f-af5f-bba416d78823)

I checked how other popular packages define versions and most just do: `>=3.8` or `>=3.9` they don't bother with upper bounds, settings this fixes my issue.

example: https://github.com/psf/requests/blob/0e322af87745eff34caffe4df68456ebc20d9068/setup.py#L97C5-L97C28
## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
