### PR TITLE
Javascript: Fixing type declaration on export in package.json

### DIFF
--- a/cratedb_sqlparse_js/package.json
+++ b/cratedb_sqlparse_js/package.json
@@ -36,7 +36,8 @@
   "exports": {
     ".": {
       "import": "./dist/sqlparse.js",
-      "require": "./dist/sqlparse.umd.cjs"
+      "require": "./dist/sqlparse.umd.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "dependencies": {


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
I got this error while integrating this library in `crate-gc-admin`:

```
Could not find a declaration file for module '@cratedb/cratedb-sqlparse'.
'crate-gc-admin/node_modules/@cratedb/cratedb-sqlparse/dist/sqlparse.js' implicitly has an 'any' type.
There are types at 'crate-gc-admin/node_modules/@cratedb/cratedb-sqlparse/dist/index.d.ts', 
but this result could not be resolved when respecting package.json "exports". 
The '@cratedb/cratedb-sqlparse' library may need to update its package.json or typings.
```

Basically, for react with typescript projects, the [export](https://github.com/crate/cratedb-sqlparse/blob/main/cratedb_sqlparse_js/package.json#L36) in the `package.json` is "explicit", so even if types are declared [here](https://github.com/crate/cratedb-sqlparse/blob/main/cratedb_sqlparse_js/package.json#L35), it is necessary to declare them a second time inside the `export`. I have also noticed that this has been done also for [`crate-gc-admin`](https://github.com/crate/crate-gc-admin/blob/master/package.json#L22).

## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/cratedb-sqlparse/issues/52
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
