### PR TITLE
Match error singlestmt

### DIFF
--- a/cratedb_sqlparse_js/cratedb_sqlparse/parser.js
+++ b/cratedb_sqlparse_js/cratedb_sqlparse/parser.js
@@ -223,7 +223,14 @@ export function sqlparse(query, raise_exception = false) {
     let statements = []
     for (const statementContext of statementsContext) {
         let stmt = new Statement(statementContext)
-        findSuitableError(stmt, errorListener.errors)
+
+        if (statementsContext.length === 1 && errorListener.errors) {
+            stmt.exception = errorListener.errors.pop();
+
+        } else {
+            findSuitableError(stmt, errorListener.errors)
+        }
+
         statements.push(stmt)
     }
 

--- a/cratedb_sqlparse_py/cratedb_sqlparse/parser.py
+++ b/cratedb_sqlparse_py/cratedb_sqlparse/parser.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List
 
 from antlr4 import CommonTokenStream, InputStream, RecognitionException, Token


### PR DESCRIPTION
When there is only one parsed statement, just assign the error to the statement (it only takes the first one from .pop, if there are more it's ignored as currently our Statment object only has ONE possible error)