### PR TITLE
Chore: Update to `poethepoet<1`

### DIFF
--- a/cratedb_sqlparse_py/pyproject.toml
+++ b/cratedb_sqlparse_py/pyproject.toml
@@ -70,7 +70,7 @@ dependencies = [
 optional-dependencies.develop = [
   "mypy<1.16",
   "packaging",
-  "poethepoet<0.33",
+  "poethepoet<1",
   "pyproject-fmt<2.6",
   "ruff<0.10",
   "validate-pyproject<0.24",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 antlr4-tools<0.3
-poethepoet<0.33
+poethepoet<1
 requests<3


### PR DESCRIPTION
[poethepoet](https://pypi.org/project/poethepoet/)'s standard interfaces are considered stable enough, so this patch intends to reduce future Dependabot traffic.

The patch will make those obsolete:
- GH-153
- GH-155

/cc @tomach, @Taliik, @juanpardo 