### PR TITLE
Python: Permit installation on Python 3.8

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -35,7 +35,14 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: [
+          "3.8",
+          "3.9",
+          "3.10",
+          "3.11",
+          "3.12",
+          "3.13",
+        ]
 
     env:
       OS: ${{ matrix.os }}

--- a/cratedb_sqlparse_py/pyproject.toml
+++ b/cratedb_sqlparse_py/pyproject.toml
@@ -17,7 +17,7 @@ license = { text = "Apache License 2.0" }
 authors = [
   { name = "Ivan Sanchez Valencia", email = "ivan.sanchezvalencia@crate.io" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
@@ -35,6 +35,7 @@ classifiers = [
   "Operating System :: Unix",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## About
Even if EOL, some projects still provide support for Python 3.8.

NB: Please rebase and merge only after integrating GH-174, to validate the patch does not break CI.

## References
- https://github.com/crate/cratedb-toolkit/pull/412